### PR TITLE
#135 Added inter-node webserver failure management

### DIFF
--- a/lib/common/globals.js
+++ b/lib/common/globals.js
@@ -9,7 +9,11 @@
  **/
 
 
-var stopped = false;
+var
+  os = require('os'),
+  cluster = require('cluster');
+
+global.stopped = false;
 global.shutdown = function (code, callback) {
   if (stopped)
     return;
@@ -18,12 +22,25 @@ global.shutdown = function (code, callback) {
   joola.logger.info('Gracefully shutting down, code: ' + code);
   joola.state.set('core', 'stop', 'received code [' + code + ']+');
   joola.dispatch.emit('nodes:state:change', [joola.UID, joola.state.get()]);
-  if (typeof callback === 'function')
-    return joola.redis.del('nodes:' + joola.UID, callback);
+
+  var node = nodeState();
+  if (node.http) {
+    //We're running an http node, let's try to start another one.
+    joola.logger.info('Trying to start Web Services on another node');
+    joola.dispatch.request(0, 'startWebServer', [node], function () {
+      //do we care?
+    });
+  }
+  joola.redis.del('nodes:' + joola.UID, function () {
+    //do we care?
+  });
 
   setTimeout(function () {
     process.exit(code || 0);
   }, 10);
+
+  if (typeof callback === 'function')
+    return callback(null);
 };
 
 global.emptyfunc = function () {
@@ -36,4 +53,48 @@ global.rt = function () {
       return console.log('Roundtrip: ' + err);
     return console.log('Roundtrip: ' + delta + 'ms');
   });
+};
+
+
+var hostname = joola.hostname = os.hostname();
+var isCluster = false; //Object.keys(cluster.workers).length > 0;
+var clusterID = null;// = cluster.worker ? cluster.worker.id : null;
+var isMaster = null;// = Object.keys(cluster.workers).length > 0 ? cluster.isMaster : null;
+var isWorker = null;// = Object.keys(cluster.workers).length > 0 ? cluster.isWorker : null;
+
+try {
+  if (typeof cluster.workers === 'object') {
+    if (cluster.workers === null) {
+      isCluster = true;
+      clusterID = cluster.worker ? cluster.worker.id : null;
+      isMaster = cluster.isMaster;
+      isWorker = cluster.isWorker;
+    }
+  }
+}
+catch (ex) {
+  //ignore errors
+}
+global.nodeState = function () {
+  var state = joola.state.get();
+  var status = state.status;
+
+  var result = {
+    uid: joola.UID,
+    state: status,
+    uptime: process.uptime(),
+    'last-seen': new Date().getTime(),
+    'last-seen-nice': new Date(),
+    hostname: hostname,
+    'usage-cpu': null,
+    'usage-mem': null,
+    http: joola.webserver.http._handle ? true : false,
+    https: joola.webserver.https._handle ? true : false,
+    cluster: isCluster,
+    'cluster-id': clusterID,
+    'cluster-master': isMaster,
+    'cluster-slave': isWorker
+  };
+
+  return result;
 };

--- a/lib/common/stats.js
+++ b/lib/common/stats.js
@@ -191,6 +191,11 @@ stats.queries.nodecount = {
  * ```
  */
 stats.statsEvents = function () {
+  if (!joola.io) {
+    setTimeout(stats.statsEvents, stats.emitInterval);
+    return;
+  }
+
   Object.keys(stats.queries).forEach(function (group) {
     group = stats.queries[group];
     Object.keys(group).forEach(function (query) {
@@ -379,10 +384,8 @@ stats.set = function (key, value, callback) {
 };
 
 joola.events.on('init:done', function () {
-  if (joola.io) {
-    if (cluster.worker && cluster.worker.id == 1)
-      setTimeout(stats.statsEvents, stats.emitInterval);
-    else if (!cluster.worker)
-      setTimeout(stats.statsEvents, stats.emitInterval);
-  }
+  if (cluster.worker && cluster.worker.id == 1)
+    setTimeout(stats.statsEvents, stats.emitInterval);
+  else if (!cluster.worker)
+    setTimeout(stats.statsEvents, stats.emitInterval);
 });

--- a/lib/common/watchers.js
+++ b/lib/common/watchers.js
@@ -18,22 +18,23 @@ function watch_eventloop() {
   var lastTime = new Date().getTime();
   setInterval(function () {
     var delta = new Date().getTime() - lastTime;
-    if (delta > 150) {
+    if (delta > 1500) {
       joola.stats.set('eventlooplocks', {
         eventlooplocks$sum: 1
       });
       joola.logger.warn('Blocked event-loop, ' + delta.toString() + 'ms, since: ' + new Date(lastTime).format('hh:nn:ss.fff'));
     }
     lastTime = new Date().getTime();
-  }, 100);
+  }, 1000);
 }
 
 function watch_state() {
   var lastStatus = 'failure';
 
   joola.dispatch.on('nodes:state:change', function (channel, message) {
-    if (message[0] != joola.UID)
+    if (message[0] != joola.UID) {
       joola.logger.info('Detected node [' + message[0] + '] has changed state to [' + message[1].status + ']');
+    }
     else
       joola.logger.info('State changed to [' + message[1].status + ']');
 
@@ -50,7 +51,7 @@ function watch_state() {
       joola.state.emit('state:change', status);
       joola.dispatch.emit('nodes:state:change', [joola.UID, joola.state.get()]);
     }
-  }, 500);
+  }, 1000);
 }
 
 function node_ping() {
@@ -77,22 +78,15 @@ function node_ping() {
   }
 
   var ping = function () {
-    var state = joola.state.get();
-    var status = state.status;
 
-    joola.redis.hset(key, 'uid', joola.UID);
-    joola.redis.expire(key, 6);
-    joola.redis.hset(key, 'state', status);
-    joola.redis.hset(key, 'uptime', process.uptime());
-    joola.redis.hset(key, 'usage-cpu', lastUsage.cpu);
-    joola.redis.hset(key, 'usage-mem', lastUsage.memory);
-    joola.redis.hset(key, 'last-seen', new Date().getTime());
-    joola.redis.hset(key, 'last-seen-nice', new Date());
-    joola.redis.hset(key, 'hostname', hostname);
-    joola.redis.hset(key, 'cluster', isCluster);
-    joola.redis.hset(key, 'cluster-id', clusterID);
-    joola.redis.hset(key, 'cluster-master', isMaster);
-    joola.redis.hset(key, 'cluster-slave', isWorker);
+    var node = nodeState();
+    node['usage-cpu'] = lastUsage.cpu;
+    node['usage-mem'] = lastUsage.memory;
+
+    joola.redis.hmset(key, node, function (err) {
+      joola.redis.expire(key, 6);
+    });
+
   };
 
   joola.state.on('state:change', ping);

--- a/lib/dispatch/index.js
+++ b/lib/dispatch/index.js
@@ -122,6 +122,9 @@ dispatch.setup = function (fn, callback) {
 };
 
 dispatch.router = function (channel, message) {
+  if (global.stopped)
+    return;
+
   var listener;
   listener = _.find(dispatch.listeners, function (l) {
     return l._dispatch.message == channel.replace('-request', '').replace('-done', '');
@@ -183,6 +186,7 @@ dispatch.router = function (channel, message) {
 
                   dispatch.fulfill(message, _result);
                 });
+
                 listener.run.apply(message, _params);
               });
             });
@@ -244,9 +248,13 @@ dispatch.shouldRun = function (listener, message, callback) {
   if (!listener)
     return callback(new Error('Failed to locate listener for message [' + message.id + ']'));
 
-  if (message.picked <= listener._dispatch.limit)
+  if (listener._dispatch.limit > -1) {
+    if (message.picked <= listener._dispatch.limit)
+      result = true;
+  }
+  else {
     result = true;
-
+  }
   return callback(null, result);
 };
 

--- a/lib/dispatch/system.js
+++ b/lib/dispatch/system.js
@@ -11,6 +11,7 @@
 
 
 var
+  os = require('os'),
   router = require('../webserver/routes/index');
 
 
@@ -72,16 +73,46 @@ exports.terminate = {
   _outputExample: {},
   _permission: ['manage_system'],
   _dispatch: {
-    message: 'terminate'
+    message: 'terminate',
+    limit: -1
   },
   _route: null,
   run: function (uid, callback) {
     callback = callback || emptyfunc;
     if (uid == joola.UID) {
       global.shutdown();
-      return callback(null, true);
+      return callback(null);
     }
-    return callback(null, false);
+  }
+};
+
+exports.startWebServer = {
+  name: "/api/system/startWebServer",
+  description: "I start a WebServer on a node",
+  inputs: ['node'],
+  _outputExample: {},
+  _permission: ['manage_system'],
+  _dispatch: {
+    message: 'startWebServer'
+  },
+  _route: null,
+  run: function (node, callback) {
+    callback = callback || emptyfunc;
+    var found = false;
+    if (node.hostname == os.hostname()) {
+      found = true;
+      joola.logger.info('Detected request to start web server in exchange of [' + node.uid + '], allowing grace...');
+      setTimeout(function () {
+        joola.logger.info('Attempting start of web server in exchange of [' + node.uid + ']');
+        joola.webserver.start({}, function (err) {
+          if (err)
+            return callback(err);
+          return callback(null, true);
+        });
+      }, 3000);
+    }
+    if (!found)
+      return callback(null);
   }
 };
 

--- a/lib/joola.io.js
+++ b/lib/joola.io.js
@@ -58,7 +58,7 @@ joola.config.init(function (err) {
     if (err)
       throw err;
     joola.dispatch.hook();
-    joola.webserver.start({}, function (err) {
+    joola.webserver.start({}, function (err, http) {
       if (err) {
         joola.logger.error('Webserver startup reported an issue, exiting: ' + (typeof(err) === 'object' ? err.message : err));
         return shutdown(1);
@@ -84,6 +84,9 @@ joola.config.init(function (err) {
         //webserver is live (if it should be)
         joola.events.emit('init:done', 1);
       }
+
+
+
     });
   });
 

--- a/lib/webserver/index.js
+++ b/lib/webserver/index.js
@@ -154,15 +154,18 @@ webserver.start = function (options, callback) {
       return callback(null, self.http);
     }).on('error',function (err) {
         if (err.code == 'EADDRINUSE' && joola.config.get('webserver')) {
+
           //fireof an immediate callback with the error
           return callback(err);
         }
         else if (err.code == 'EADDRINUSE') {
           joola.logger.debug('[ignore] joola.io HTTP server server error: ' + (typeof(err) === 'object' ? err.message : err));
           joola.state.set('webserver-http', 'working', 'HTTP webserver-https is disabled.');
+          return callback(null);
         }
         else {
           joola.logger.debug('joola.io HTTP server error: ' + (typeof(err) === 'object' ? err.message : err));
+          return callback(err);
         }
       }).on('close', function () {
         joola.logger.debug('joola.io HTTP server listening on port ' + self.options.port + ' received a CLOSE command.');
@@ -197,9 +200,11 @@ webserver.start = function (options, callback) {
         else if (err.code == 'EADDRINUSE') {
           joola.logger.debug('[ignore] joola.io HTTPS server server error: ' + (typeof(err) === 'object' ? err.message : err));
           joola.state.set('webserver-https', 'working', 'HTTPS webserver-https is disabled.');
+          return callback(null);
         }
         else {
           joola.logger.debug('joola.io HTTPS server error: ' + (typeof(err) === 'object' ? err.message : err));
+          return callback(err);
         }
       }).on('close', function () {
         joola.logger.debug('joola.io HTTPS server listening on port ' + self.options.securePort + ' received a CLOSE command.');
@@ -217,7 +222,7 @@ webserver.start = function (options, callback) {
   if (!joola.config.get('webserver')) {
     delete joola.state.controls['webserver-https'];
   }
-  async.parallel(calls, function (err) {
+  async.series(calls, function (err) {
     if (typeof callback === 'function')
       callback(err);
   });

--- a/lib/webserver/public/manage/js/nodes.js
+++ b/lib/webserver/public/manage/js/nodes.js
@@ -14,8 +14,9 @@ function updateNode(node) {
   $container.find('.node-memory').html(Math.round(node['usage-mem'] / 1024 / 1024) + 'mb');
 
   $container.find('.btn-terminate').on('click', function () {
+    console.log('terminate');
     joolaio.dispatch.system.terminate(node.uid, function () {
-
+      console.log('terminated');
     });
   });
 

--- a/lib/webserver/routes/index.js
+++ b/lib/webserver/routes/index.js
@@ -116,6 +116,11 @@ exports.logger = function (req, res) {
 };
 
 exports.route = function (req, res) {
+  //check if we're stopped (emergency was called)
+  if (global.stopped)
+    if (res.render)
+      return res.render('server-offline');
+
   if (joola.state.get().status != 'online') {
     if (res.render)
       return res.render('server-offline');


### PR DESCRIPTION
Resolves #135, #115 
- You can now terminate nodes from management console.
- In case a node with http services fails, it bails with a startWebServer message for all other nodes.
