### PR TITLE
#113 Added security context to dispatch

### DIFF
--- a/lib/dispatch/beacon.js
+++ b/lib/dispatch/beacon.js
@@ -285,7 +285,7 @@ exports.insert = {
   _dispatch: {
     message: 'beacon:insert'
   },
-  run: function (collection, document, callback) {
+  run: function (context, collection, document, callback) {
     callback = callback || emptyfunc;
 
     return etl.verify(collection, document).transform(collection, document).load(collection, document, {}, callback);

--- a/lib/dispatch/collections.js
+++ b/lib/dispatch/collections.js
@@ -47,7 +47,7 @@ exports.list = {
   _dispatch: {
     message: 'collections:list'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
     joola.config.get('datamap:collections', function (err, value) {
       if (err) {
@@ -92,7 +92,7 @@ exports.get = {
   _dispatch: {
     message: 'collections:get'
   },
-  run: function (id, callback) {
+  run: function (context, id, callback) {
     callback = callback || emptyfunc;
     joola.config.get('datamap:collections:' + id, function (err, value) {
       if (err)
@@ -142,7 +142,7 @@ exports.add = {
   _dispatch: {
     message: 'collections:add'
   },
-  run: function (collection, callback) {
+  run: function (context, collection, callback) {
     callback = callback || emptyfunc;
     try {
       collection = new Proto(collection);
@@ -209,7 +209,7 @@ exports.update = {
   _dispatch: {
     message: 'collections:update'
   },
-  run: function (collection, callback) {
+  run: function (context, collection, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -275,10 +275,10 @@ exports.delete = {
   _dispatch: {
     message: 'collections:delete'
   },
-  run: function (id, callback) {
+  run: function (context, id, callback) {
     callback = callback || emptyfunc;
 
-    exports.get.run(id, function (err, value) {
+    exports.get.run(context, id, function (err, value) {
       if (err)
         return callback(err);
 
@@ -334,10 +334,10 @@ exports.stats = {
   _dispatch: {
     message: 'collections:stats'
   },
-  run: function (id, callback) {
+  run: function (context, id, callback) {
     callback = callback || emptyfunc;
 
-    exports.get.run(id, function (err, value) {
+    exports.get.run(context, id, function (err, value) {
       if (err)
         return callback(err);
 
@@ -385,13 +385,13 @@ exports.maxdate = {
   _dispatch: {
     message: 'collections:maxdate'
   },
-  run: function (id, key, callback) {
+  run: function (context, id, key, callback) {
     if (typeof key === 'function') {
       callback = key;
       key = null;
     }
 
-    exports.get.run(id, function (err, value) {
+    exports.get.run(context, id, function (err, value) {
       if (err)
         return callback(err);
 
@@ -444,14 +444,14 @@ exports.mindate = {
   _dispatch: {
     message: 'collections:mindate'
   },
-  run: function (id, key, callback) {
+  run: function (context, id, key, callback) {
     if (typeof key === 'function') {
       callback = key;
       key = null;
     }
     callback = callback || emptyfunc;
 
-    exports.get.run(id, function (err, value) {
+    exports.get.run(context, id, function (err, value) {
       if (err)
         return callback(err);
 

--- a/lib/dispatch/dimensions.js
+++ b/lib/dispatch/dimensions.js
@@ -45,7 +45,7 @@ exports.list = {
   _dispatch: {
     message: 'dimensions:list'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
     joola.config.get('dimensions', function (err, value) {
       if (err)
@@ -90,7 +90,7 @@ exports.get = {
   _dispatch: {
     message: 'dimensions:get'
   },
-  run: function (name, callback) {
+  run: function (context, name, callback) {
     callback = callback || emptyfunc;
     joola.config.get('dimensions:' + name, function (err, value) {
       if (err)
@@ -141,7 +141,7 @@ exports.add = {
   _dispatch: {
     message: 'dimensions:add'
   },
-  run: function (dimension, callback) {
+  run: function (context, dimension, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -219,7 +219,7 @@ exports.update = {
   _dispatch: {
     message: 'dimensions:update'
   },
-  run: function (dimension, callback) {
+  run: function (context, dimension, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -290,10 +290,10 @@ exports.delete = {
   _dispatch: {
     message: 'dimensions:delete'
   },
-  run: function (dimension, callback) {
+  run: function (context, dimension, callback) {
     callback = callback || emptyfunc;
 
-    exports.get.run(dimension.name, function (err, value) {
+    exports.get.run(context, dimension.name, function (err, value) {
       if (err)
         return callback(err);
 

--- a/lib/dispatch/index.js
+++ b/lib/dispatch/index.js
@@ -153,6 +153,7 @@ dispatch.router = function (channel, message) {
         //do something
         return;
       }
+
       if (!value)
         return;
       message = value;
@@ -168,51 +169,73 @@ dispatch.router = function (channel, message) {
       if (channel.indexOf('-request') > -1) {
         //we're dealing with a request
 
-        dispatch.qualifies(listener, message, function (err, qualified) {
-          if (!qualified)
-            return;
+        joola.auth.getUserByToken(message.token, function (err, user) {
+          if (err) {
+            var _result = {
+              err: err,
+              message: null
+            };
+            dispatch.fulfill(message, _result);
+          }
+          /*
+           if (!user) {
+           var _result = {
+           err: 'Failed to translate token to user.',
+           message: null
+           };
+           dispatch.fulfill(message, _result);
+           }*/
 
-          dispatch.redis.hincrby('messages:' + message.id, 'picked', 1, function (err, value) {
-            message.picked = value;
-            dispatch.shouldRun(listener, message, function (err, should) {
-              if (!should) {
-                joola.logger.trace('[router] should not run message [' + message.id + ']');
-                return;
-              }
+          var context = {};
+          context.user = user;
 
-              joola.common.parse(message.payload, function (err, payload) {
-                var _params = [];
-                if (payload && typeof payload === 'object') {
-                  Object.keys(payload).forEach(function (key) {
-                    try {
-                      _params.push(JSON.parse(payload[key]));
-                    } catch (ex) {
-                      _params.push(payload[key]);
-                    }
+          dispatch.qualifies(context, listener, message, function (err, qualified) {
+            if (!qualified)
+              return;
+
+            dispatch.redis.hincrby('messages:' + message.id, 'picked', 1, function (err, value) {
+              message.picked = value;
+              dispatch.shouldRun(listener, message, function (err, should) {
+                if (!should) {
+                  joola.logger.trace('[router] should not run message [' + message.id + ']');
+                  return;
+                }
+                joola.common.parse(message.payload, function (err, payload) {
+                  var _params = [];
+                  _params.push(context);
+
+                  if (payload && typeof payload === 'object') {
+                    Object.keys(payload).forEach(function (key) {
+                      try {
+                        _params.push(JSON.parse(payload[key]));
+                      } catch (ex) {
+                        _params.push(payload[key]);
+                      }
+                    });
+                  }
+                  else if (message.payload != '{}') {
+                    _params.push(message.payload);
+                  }
+                  _params.push(function (err, result) {
+                    var _result = {
+                      err: err,
+                      message: result
+                    };
+
+                    dispatch.fulfill(message, _result);
                   });
-                }
-                else if (message.payload != '{}') {
-                  _params.push(message.payload);
-                }
-                _params.push(function (err, result) {
-                  var _result = {
-                    err: err,
-                    message: result
-                  };
 
-                  dispatch.fulfill(message, _result);
+                  try {
+                    listener.run.apply(message, _params);
+                  }
+                  catch (ex) {
+                    var _result = {
+                      err: ex,
+                      message: null
+                    };
+                    dispatch.fulfill(message, _result);
+                  }
                 });
-
-                try {
-                  listener.run.apply(message, _params);
-                }
-                catch (ex) {
-                  var _result = {
-                    err: ex,
-                    message: null
-                  };
-                  dispatch.fulfill(message, _result);
-                }
               });
             });
           });
@@ -238,36 +261,39 @@ dispatch.router = function (channel, message) {
   }
 };
 
-dispatch.qualifies = function (listener, message, callback) {
+dispatch.qualifies = function (context, listener, message, callback) {
   var qualifies = true;
-  switch (listener._dispatch.criteria) {
-    case 'notme':
-      joola.dispatch.system.listnodes(function (err, nodes) {
-        var exist = _.find(nodes, function (n) {
-          if (n && n['last-seen']) {
-            var lastSeen = new Date().getTime() - parseInt(n['last-seen']);
-            return lastSeen < 5000 && n.uid != joola.UID;
+  if (listener._dispatch.criteria) {
+    switch (listener._dispatch.criteria) {
+      case 'notme':
+        joola.dispatch.system.listnodes(context, function (err, nodes) {
+          var exist = _.find(nodes, function (n) {
+            if (n && n['last-seen']) {
+              var lastSeen = new Date().getTime() - parseInt(n['last-seen']);
+              return lastSeen < 5000 && n.uid != joola.UID;
+            }
+          });
+          if (message.from == joola.UID && !exist) {
+            joola.logger.trace('[router] Qualified [no candidates] to run [' + message.id + ']');
+            qualifies = true;
           }
+          else if (message.from == joola.UID) {
+            joola.logger.trace('[router] not qualified to run [' + message.id + '], first example: ' + exist.uid);
+            qualifies = false;
+          }
+          else {
+            joola.logger.trace('[router] Qualified [opportunist] to run [' + message.id + ']');
+            qualifies = true;
+          }
+          return callback(null, qualifies);
         });
-        if (message.from == joola.UID && !exist) {
-          joola.logger.trace('[router] Qualified [no candidates] to run [' + message.id + ']');
-          qualifies = true;
-        }
-        else if (message.from == joola.UID) {
-          joola.logger.trace('[router] not qualified to run [' + message.id + '], first example: ' + exist.uid);
-          qualifies = false;
-        }
-        else {
-          joola.logger.trace('[router] Qualified [opportunist] to run [' + message.id + ']');
-          qualifies = true;
-        }
+        break;
+      default:
         return callback(null, qualifies);
-      });
-
-      break;
-    default:
-      return callback(null, qualifies);
+    }
   }
+  else
+    return callback(null, qualifies);
 };
 
 dispatch.shouldRun = function (listener, message, callback) {

--- a/lib/dispatch/logger.js
+++ b/lib/dispatch/logger.js
@@ -23,7 +23,7 @@ exports.fetch = {
   _dispatch: {
     message: 'logger:fetch'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
 
     mongo.find('logger', 'events', {}, {sort: {time: -1}, limit: 100}, function (err, logs) {
@@ -41,7 +41,7 @@ exports.fetchSince = {
   _dispatch: {
     message: 'logger:fetchSince'
   },
-  run: function (start_ts, callback) {
+  run: function (context, start_ts, callback) {
     callback = callback || emptyfunc;
 
     mongo.find('logger', 'events', {time: {$gt: new Date(start_ts)}}, {sort: {time: 1}, limit: 20}, function (err, logs) {
@@ -59,7 +59,7 @@ exports.fetchUntil = {
   _dispatch: {
     message: 'logger:fetchUntil'
   },
-  run: function (end_ts, callback) {
+  run: function (context, end_ts, callback) {
     callback = callback || emptyfunc;
 
     mongo.find('logger', 'events', {time: {$lt: new Date(end_ts)}}, {sort: {time: -1}, limit: 100}, function (err, logs) {

--- a/lib/dispatch/metrics.js
+++ b/lib/dispatch/metrics.js
@@ -45,7 +45,7 @@ exports.list = {
   _dispatch: {
     message: 'metrics:list'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
     joola.config.get('metrics', function (err, value) {
       if (err)
@@ -90,7 +90,7 @@ exports.get = {
   _dispatch: {
     message: 'metrics:get'
   },
-  run: function (name, callback) {
+  run: function (context, name, callback) {
     callback = callback || emptyfunc;
     joola.config.get('metrics:' + name, function (err, value) {
       if (err)
@@ -141,7 +141,7 @@ exports.add = {
   _dispatch: {
     message: 'metrics:add'
   },
-  run: function (metric, callback) {
+  run: function (context, metric, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -219,7 +219,7 @@ exports.update = {
   _dispatch: {
     message: 'metrics:update'
   },
-  run: function (metric, callback) {
+  run: function (context, metric, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -290,10 +290,10 @@ exports.delete = {
   _dispatch: {
     message: 'metrics:delete'
   },
-  run: function (metric, callback) {
+  run: function (context, metric, callback) {
     callback = callback || emptyfunc;
 
-    exports.get.run(metric.name, function (err, value) {
+    exports.get.run(context, metric.name, function (err, value) {
       if (err)
         return callback(err);
 

--- a/lib/dispatch/organizations.js
+++ b/lib/dispatch/organizations.js
@@ -47,7 +47,7 @@ exports.list = {
   _dispatch: {
     message: 'organizations:list'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
     joola.config.get('authentication:organizations', function (err, value) {
       if (err) {
@@ -92,7 +92,7 @@ exports.get = {
   _dispatch: {
     message: 'organizations:get'
   },
-  run: function (orgname, callback) {
+  run: function (context, orgname, callback) {
     callback = callback || emptyfunc;
     joola.config.get('authentication:organizations:' + orgname, function (err, value) {
       if (err)
@@ -142,7 +142,7 @@ exports.add = {
   _dispatch: {
     message: 'organizations:add'
   },
-  run: function (org, callback) {
+  run: function (context, org, callback) {
     callback = callback || emptyfunc;
     try {
       org = new Proto(org);
@@ -209,7 +209,7 @@ exports.update = {
   _dispatch: {
     message: 'organizations:update'
   },
-  run: function (org, callback) {
+  run: function (context, org, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -275,10 +275,10 @@ exports.delete = {
   _dispatch: {
     message: 'organizations:delete'
   },
-  run: function (org, callback) {
+  run: function (context, org, callback) {
     callback = callback || emptyfunc;
 
-    exports.get.run(org.name, function (err, value) {
+    exports.get.run(context, org.name, function (err, value) {
       if (err)
         return callback(err);
 

--- a/lib/dispatch/permissions.js
+++ b/lib/dispatch/permissions.js
@@ -46,7 +46,7 @@ exports.list = {
   _dispatch: {
     message: 'permissions:list'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
     joola.config.get('authentication:permissions', function (err, value) {
       if (err) {
@@ -93,7 +93,7 @@ exports.get = {
   _dispatch: {
     message: 'permissions:get'
   },
-  run: function (permissionname, callback) {
+  run: function (context, permissionname, callback) {
     callback = callback || emptyfunc;
     joola.config.get('authentication:permissions:' + permissionname, function (err, value) {
       if (err)
@@ -143,7 +143,7 @@ exports.add = {
   _dispatch: {
     message: 'permissions:add'
   },
-  run: function (permission, callback) {
+  run: function (context, permission, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -211,7 +211,7 @@ exports.update = {
   _dispatch: {
     message: 'permissions:update'
   },
-  run: function (permission, callback) {
+  run: function (context, permission, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -277,10 +277,10 @@ exports.delete = {
   _dispatch: {
     message: 'permissions:delete'
   },
-  run: function (permission, callback) {
+  run: function (context, permission, callback) {
     callback = callback || emptyfunc;
 
-    exports.get.run(permission.name, function (err, value) {
+    exports.get.run(context, permission.name, function (err, value) {
       if (err)
         return callback(err);
 

--- a/lib/dispatch/query.js
+++ b/lib/dispatch/query.js
@@ -494,7 +494,7 @@ exports.fetch = {
     }
     request();
   },
-  run: function (options, callback) {
+  run: function (context, options, callback) {
     callback = callback || emptyfunc;
 
     options = joola.common.extend({

--- a/lib/dispatch/roles.js
+++ b/lib/dispatch/roles.js
@@ -46,7 +46,7 @@ exports.list = {
   _dispatch: {
     message: 'roles:list'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
     joola.config.get('authentication:roles', function (err, value) {
       if (err) {
@@ -90,7 +90,7 @@ exports.get = {
   _dispatch: {
     message: 'roles:get'
   },
-  run: function (rolename, callback) {
+  run: function (context, rolename, callback) {
     callback = callback || emptyfunc;
     joola.config.get('authentication:roles:' + rolename, function (err, value) {
       if (err)
@@ -140,7 +140,7 @@ exports.add = {
   _dispatch: {
     message: 'roles:add'
   },
-  run: function (role, callback) {
+  run: function (context, role, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -208,7 +208,7 @@ exports.update = {
   _dispatch: {
     message: 'roles:update'
   },
-  run: function (role, callback) {
+  run: function (context, role, callback) {
     callback = callback || emptyfunc;
 
     try {
@@ -274,10 +274,10 @@ exports.delete = {
   _dispatch: {
     message: 'roles:delete'
   },
-  run: function (role, callback) {
+  run: function (context, role, callback) {
     callback = callback || emptyfunc;
 
-    exports.get.run(role.name, function (err, value) {
+    exports.get.run(context, role.name, function (err, value) {
       if (err)
         return callback(err);
 

--- a/lib/dispatch/system.js
+++ b/lib/dispatch/system.js
@@ -26,7 +26,7 @@ exports.listnodes = {
   _dispatch: {
     message: 'system:listnodes'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
 
     var nodes = [];
@@ -59,7 +59,7 @@ exports.roundtrip = {
     message: 'roundtrip'
   },
   _route: null,
-  run: function (start, callback) {
+  run: function (context, start, callback) {
     callback = callback || emptyfunc;
     var duration = new Date().getTime() - parseInt(start);
     return callback(null, duration);
@@ -77,7 +77,7 @@ exports.terminate = {
     limit: -1
   },
   _route: null,
-  run: function (uid, callback) {
+  run: function (context, uid, callback) {
     callback = callback || emptyfunc;
     if (uid == joola.UID) {
       global.shutdown();
@@ -96,7 +96,7 @@ exports.startWebServer = {
     message: 'startWebServer'
   },
   _route: null,
-  run: function (node, callback) {
+  run: function (context, node, callback) {
     callback = callback || emptyfunc;
     var found = false;
     if (node.hostname == os.hostname()) {
@@ -126,7 +126,7 @@ exports.dummy = {
     message: 'dummy'
   },
   _route: null,
-  run: function (start, callback) {
+  run: function (context, start, callback) {
     callback = callback || emptyfunc;
 
 
@@ -144,7 +144,7 @@ exports.block = {
     message: 'block'
   },
   _route: null,
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
 
     console.time('blocking-loop');
@@ -171,7 +171,7 @@ exports.subscribe_dispatch = {
     criteria: 'all'
   },
   _route: null,
-  run: function (socketid, callback) {
+  run: function (context, socketid, callback) {
     callback = callback || emptyfunc;
 
     joola.dispatch.tracers.push(socketid);

--- a/lib/dispatch/users.js
+++ b/lib/dispatch/users.js
@@ -46,7 +46,7 @@ exports.list = {
   _dispatch: {
     message: 'users:list'
   },
-  run: function (callback) {
+  run: function (context, callback) {
     callback = callback || emptyfunc;
     joola.config.get('authentication:users', function (err, value) {
       if (err) {
@@ -95,7 +95,7 @@ exports.get = {
   _dispatch: {
     message: 'users:get'
   },
-  run: function (username, callback) {
+  run: function (context, username, callback) {
     callback = callback || emptyfunc;
     joola.config.get('authentication:users:' + username, function (err, value) {
       try {
@@ -145,7 +145,7 @@ exports.getByToken = {
   _dispatch: {
     message: 'users:getByToken'
   },
-  run: function (username, callback) {
+  run: function (context, username, callback) {
     callback = callback || emptyfunc;
     joola.auth.getUserByToken(username, function (err, value) {
       return callback(err, value);
@@ -187,7 +187,7 @@ exports.add = {
   _dispatch: {
     message: 'users:add'
   },
-  run: function (user, callback) {
+  run: function (context, user, callback) {
     callback = callback || emptyfunc;
 
     new Proto(user, function (err, user) {
@@ -259,7 +259,7 @@ exports.update = {
   _dispatch: {
     message: 'users:update'
   },
-  run: function (user, callback) {
+  run: function (context, user, callback) {
     callback = callback || emptyfunc;
 
     //new Proto(user, function (err, user) {
@@ -328,10 +328,10 @@ exports.delete = {
   _dispatch: {
     message: 'users:delete'
   },
-  run: function (user, callback) {
+  run: function (context, user, callback) {
     callback = callback || emptyfunc;
 
-    exports.get.run(user.username, function (err, value) {
+    exports.get.run(context, user.username, function (err, value) {
       if (err)
         return callback(err);
 
@@ -380,13 +380,13 @@ exports.authenticate = {
   _dispatch: {
     message: 'users:authenticate'
   },
-  run: function (username, password, callback) {
+  run: function (context, username, password, callback) {
     if (!username)
       return callback(new Error('Username not provided'));
     if (!password)
       return callback(new Error('Password not provided'));
 
-    exports.get.run(username, function (err, user) {
+    exports.get.run(context, username, function (err, user) {
       if (err)
         return callback(err);
 


### PR DESCRIPTION
Resolves #113.
- `run` now receives a `context` object as first param on every dispatch
