### PR TITLE
#409 config base key/cert file

### DIFF
--- a/lib/webserver/index.js
+++ b/lib/webserver/index.js
@@ -38,11 +38,9 @@ webserver.start = function (options, callback) {
     securePort: joola.config.get('interfaces:webserver:securePort'),
     secure: true,
     secureOnly: false,
-    keyFile: path.join(__dirname, '../../config/certs/localhost.key'),
-    certFile: path.join(__dirname, '../../config/certs/localhost.csr'),
+    keyFile: joola.config.get('interfaces:webserver:keyFile'),
+    certFile: joola.config.get('interfaces:webserver:certFile'),
     viewsPath: __dirname + '/views'
-    //sessionSecret: '491b8a10-573d-11e3-949a-0800200c9a66',
-    //sessionTimeout: new Date(Date.now() + 3600000)
   };
   self.options = joola.common._extend(self.options, options);
 


### PR DESCRIPTION
Resolves #409 
- changed key/cert files reference to config based instead of hardcoded
