### PR TITLE
#401 allow override by environment variables

### DIFF
--- a/lib/common/config.js
+++ b/lib/common/config.js
@@ -13,6 +13,8 @@
 var
   joola = require('../joola.io'),
 
+  _ = require('underscore'),
+  traverse = require('traverse'),
   semver = require('semver'),
   async = require('async'),
   path = require('path');
@@ -21,9 +23,27 @@ var config = exports;
 
 process.env.NODE_CONFIG_PERSIST_ON_CHANGE = 'N';
 
+config.overrideWithEnvironment = function () {
+  var configIdentifier = 'JOOLAIO_CONFIG_';
+  var joolaEnvironmentVars = {};
+  Object.keys(process.env).forEach(function (key) {
+    if (key.substring(0, configIdentifier.length) === configIdentifier) {
+      joolaEnvironmentVars[key.replace(configIdentifier, '').replace(/_/ig, '.').toLowerCase()] = process.env[key];
+    }
+  });
+  if (joolaEnvironmentVars) {
+    Object.keys(joolaEnvironmentVars).forEach(function (key) {
+      var value = joolaEnvironmentVars[key];
+      joola.common.flatGetSet(config._config, key, value);
+    });
+  }
+};
+
 config.init = function (callback) {
   //base config object, following the require config has been parsed and available for the local node. May differ from central.
   config._config = require('config');
+  config.overrideWithEnvironment();
+
   //first of all wipe any left behind configuration.
   config.shouldWatch = true;
   joola.common.extend(exports, config._config);


### PR DESCRIPTION
Resolves #401 

Environment variables can now override default.yml settings.

``` bash
export JOOLA_CONFIG_INTERFACES_WEBSERVER_PORT=8585
export JOOLA_CONFIG_STORE_REDIS_HOST=lab01.joola.io
```
