### PR TITLE
#725 added suport for range query

### DIFF
--- a/lib/webserver/routes/index.js
+++ b/lib/webserver/routes/index.js
@@ -27,7 +27,7 @@ exports.ErrorTemplate = ErrorTemplate;
 
 exports.responseError = function (code, err, req, res) {
   joola.logger.debug(err, 'Error while processing route [' + req.url + ']: ' + (typeof(err) === 'object' ? err.message : err));
-  console.trace();
+
   if (err.stack)
     joola.logger.trace(err.stack);
 

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "hiredis": "^0.2.0",
     "htpasswd": "^2.2.1",
     "joola.cli": "0.0.8",
-    "joola.datastore-elasticsearch": "^0.0.6",
+    "joola.datastore-elasticsearch": "^0.0.7",
     "joola.datastore-embedded": "^0.0.3",
     "joola.datastore-mongodb": "^0.0.15",
     "joola.sdk": "^0.8.6",

--- a/test/unit/7_query/query-filter.spec.js
+++ b/test/unit/7_query/query-filter.spec.js
@@ -143,4 +143,56 @@ describe("query-filter", function () {
       return done();
     });
   });
+
+  it("should query for ranges [gt, ES only]", function (done) {
+    var query = {
+      dimensions: [],
+      metrics: ['value', 'another'],
+      collection: this.collection,
+      filter: [
+        ['value', 'gt', 0]
+      ]
+    };
+
+    if (joola_proxy.datastore.providers.default.name !== 'ElasticSearch')
+      return done();
+
+    joola_proxy.query.fetch(this.context, query, function (err, result) {
+      if (err)
+        return done(err);
+
+      expect(result).to.be.ok;
+      expect(result.documents).to.be.ok;
+      expect(result.documents.length).to.be.greaterThan(0);
+      expect(result.documents[0].value).to.equal(3);
+      expect(result.documents[0].another).to.equal(30);
+      return done();
+    });
+  });
+
+  it("should query for ranges [gte, ES only]", function (done) {
+    var query = {
+      dimensions: [],
+      metrics: ['value', 'another'],
+      collection: this.collection,
+      filter: [
+        ['value', 'gte', 2]
+      ]
+    };
+
+    if (joola_proxy.datastore.providers.default.name !== 'ElasticSearch')
+      return done();
+
+    joola_proxy.query.fetch(this.context, query, function (err, result) {
+      if (err)
+        return done(err);
+
+      expect(result).to.be.ok;
+      expect(result.documents).to.be.ok;
+      expect(result.documents.length).to.be.greaterThan(0);
+      expect(result.documents[0].value).to.equal(2);
+      expect(result.documents[0].another).to.equal(20);
+      return done();
+    });
+  });
 });


### PR DESCRIPTION
Resolves #725 

Range filters `gt`, `lt`, `gte`, `lte` are now support for Elasticsearch. 

```
var query = {
  dimensions: [],
  metrics: ['value', 'another'],
  collection: this.collection,
  filter: [
    ['value', 'gt', 0]
  ]
};
```