### PR TITLE
#728 fixed permissions mapping

### DIFF
--- a/lib/dispatch/permissions.js
+++ b/lib/dispatch/permissions.js
@@ -21,11 +21,36 @@ var
   joola = require('../joola'),
 
   router = require('../webserver/routes/index');
-  //Proto = require('./prototypes/permission');
+//Proto = require('./prototypes/permission');
 
 
-var permissions = ['access_system', 'manage_system', 'beacon_insert', 'query'];
+var modules = {
+  users: require('./users'),
+  workspaces: require('./workspaces'),
+  roles: require('./roles'),
+  system: require('./system'),
+  beacon: require('./beacon'),
+  query: require('./query'),
+  collections: require('./collections'),
+  dimensions: require('./dimensions'),
+  metrics: require('./metrics'),
+  config: require('./config'),
+  canvases: require('./canvases'),
+  test: require('./test')
+};
 
+var permissions = [];
+Object.keys(modules).forEach(function(key) {
+  var m = modules[key];
+  Object.keys(m).forEach(function(mkey) {
+    if (m[mkey] && m[mkey]._permission) {
+      m[mkey]._permission.forEach(function(permission) {
+        if (permissions.indexOf(permission) === -1)
+          permissions.push(permission);
+      });
+    }
+  });
+});
 /**
  * @function list
  * @param {Function} [callback] called following execution with errors and results.
@@ -54,9 +79,8 @@ exports.list = {
   _dispatch: {
     message: 'permissions:list'
   },
-  run: function (context, callback) {
-    callback = callback || function () {
-    };
+  run: function(context, callback) {
+    callback = callback || function() {};
     return callback(null, permissions);
   }
 };
@@ -91,9 +115,8 @@ exports.get = {
   _dispatch: {
     message: 'permissions:get'
   },
-  run: function (context, permissionname, callback) {
-    callback = callback || function () {
-    };
+  run: function(context, permissionname, callback) {
+    callback = callback || function() {};
     if (permissions.indexOf(permissionname) === -1)
       return callback(new Error('Permission [' + permissionname + '] does not exist.'));
     return callback(null, [permissionname]);

--- a/test/unit/4_dispatch/permissions.spec.js
+++ b/test/unit/4_dispatch/permissions.spec.js
@@ -25,13 +25,13 @@ describe("permissions", function () {
   });
 
   it("should get a permission", function (done) {
-    engine.permissions.get(this.context, 'access_system', function (err, permissions) {
+    engine.permissions.get(this.context, 'query:fetch', function (err, permissions) {
       return done(err);
     });
   });
 
   it("should not get a not existing permission", function (done) {
-    engine.permissions.get(this.context, 'access_system2', function (err, permissions) {
+    engine.permissions.get(this.context, 'access_system', function (err, permissions) {
       if (err)
         return done();
       return done(new Error('This should not fail'));


### PR DESCRIPTION
Permission mapping is now based on reading the dispatch endpoints and enumerating permissions instead of hard-coded list.

Resolves #728 